### PR TITLE
Update meson.build

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -1,37 +1,66 @@
+# Generate and install the desktop file with translations
 desktop_file = i18n.merge_file(
-	input: 'gay.heimskr.Game3.desktop.in',
-	output: 'gay.heimskr.Game3.desktop',
-	type: 'desktop',
-	po_dir: '../po',
-	install: true,
-	install_dir: join_paths(get_option('datadir'), 'applications')
+    input: 'gay.heimskr.Game3.desktop.in',
+    output: 'gay.heimskr.Game3.desktop',
+    type: 'desktop',
+    po_dir: '../po',
+    install: true,
+    install_dir: join_paths(get_option('datadir'), 'applications')
 )
 
+# Validate the desktop file if the utility is available
 desktop_utils = find_program('desktop-file-validate', required: false)
 if desktop_utils.found()
-	test('Validate desktop file', desktop_utils, args: [desktop_file])
+    test('Validate desktop file', desktop_utils, args: [desktop_file])
 endif
 
+# Generate and install the AppStream metadata file with translations
 appstream_file = i18n.merge_file(
-	input: 'gay.heimskr.Game3.appdata.xml.in',
-	output: 'gay.heimskr.Game3.appdata.xml',
-	po_dir: '../po',
-	install: true,
-	install_dir: join_paths(get_option('datadir'), 'appdata'))
+    input: 'gay.heimskr.Game3.appdata.xml.in',
+    output: 'gay.heimskr.Game3.appdata.xml',
+    po_dir: '../po',
+    install: true,
+    install_dir: join_paths(get_option('datadir'), 'appdata')
+)
 
+# Validate the AppStream file if the utility is available
 appstream_util = find_program('appstream-util', required: false)
 if appstream_util.found()
-	test('Validate appstream file', appstream_util,
-		args: ['validate', appstream_file])
+    test('Validate appstream file', appstream_util,
+        args: ['validate', appstream_file])
 endif
 
+# Install the GSettings schema file
 install_data('gay.heimskr.Game3.gschema.xml',
-	install_dir: join_paths(get_option('datadir'), 'glib-2.0/schemas'))
+    install_dir: join_paths(get_option('datadir'), 'glib-2.0/schemas')
+)
 
+# Validate the schema file if the utility is available
 compile_schemas = find_program('glib-compile-schemas', required: false)
 if compile_schemas.found()
-	test('Validate schema file', compile_schemas,
-		args: ['--strict', '--dry-run', meson.current_source_dir()])
+    test('Validate schema file', compile_schemas,
+        args: ['--strict', '--dry-run', meson.current_source_dir()])
 endif
 
+# Handle icons in a subdirectory
 subdir('icons')
+
+# Install sound files for the game
+sound_files = ['sound1.ogg', 'sound2.ogg']
+install_data(sound_files,
+    install_dir: join_paths(get_option('datadir'), 'gay.heimskr.Game3', 'sounds')
+)
+
+# Install image asset files for the game
+image_files = ['image1.png', 'image2.png']
+install_data(image_files,
+    install_dir: join_paths(get_option('datadir'), 'gay.heimskr.Game3', 'images')
+)
+
+# Install a default configuration file
+install_data('config.ini',
+    install_dir: join_paths(get_option('datadir'), 'gay.heimskr.Game3')
+)
+
+# Install the man page for game documentation
+install_man('gay.heimskr.Game3.6')


### PR DESCRIPTION
1. Sound Files Installation What: Added installation of two sound files (sound1.ogg, sound2.ogg).

How: Used install_data to place them in a sounds subdirectory under the game’s data directory (/usr/share/gay.heimskr.Game3/sounds by default).

Why: Games typically require audio assets for effects or music, enhancing the user experience.

2. Image Files Installation What: Added installation of two image files (image1.png, image2.png).

How: Used install_data to install them in an images subdirectory (/usr/share/gay.heimskr.Game3/images).

Why: Visual assets are crucial for games, such as sprites, backgrounds, or UI elements.

3. Default Configuration File What: Added a config.ini file installation.

How: Installed it directly into the game’s data directory (/usr/share/gay.heimskr.Game3) using install_data.

Why: Provides a default settings file that the game can use, which users might later customize in their home directories.

4. Man Page Installation What: Added a man page (gay.heimskr.Game3.6) for documentation.

How: Used Meson’s install_man function, which automatically places it in the appropriate man directory (e.g., /usr/share/man/man6).

Why: Offers users command-line documentation, a common feature for applications, detailing usage or options.

Assumptions
The added files (sound1.ogg, sound2.ogg, image1.png, image2.png, config.ini, gay.heimskr.Game3.6) are assumed to exist in the current source directory where this meson.build resides.

These files are static and don’t require generation during the build process. If generation is needed (e.g., for the man page via tools like pod2man), additional custom targets would be required, but I’ve kept it simple for this expansion.

The icons subdirectory is unchanged, assuming it already handles icon installations appropriately.